### PR TITLE
[UPDATE] v25.1.2

### DIFF
--- a/BibleProjector-WPF/Event/KeyInputEventManager.cs
+++ b/BibleProjector-WPF/Event/KeyInputEventManager.cs
@@ -9,12 +9,16 @@ namespace BibleProjector_WPF.Event
     public class KeyInputEventManager
     {
         public delegate void KeyEventHandling(System.Windows.Input.Key key, bool isDown);
+        public delegate void KeyEventWithRepeatHandling(System.Windows.Input.Key key, bool isDown, bool isRepeat);
 
         public KeyEventHandling KeyDown;
+        public KeyEventWithRepeatHandling KeyDownWithRepeat;
 
-        public void invokeKeyInput(System.Windows.Input.Key key, bool isDown)
+        public void invokeKeyInput(System.Windows.Input.Key key, bool isDown, bool isRepeat)
         {
-            KeyDown.Invoke(key, isDown);
+            if (!isRepeat)
+                KeyDown?.Invoke(key, isDown);
+            KeyDownWithRepeat?.Invoke(key, isDown, isRepeat);
         }
     }
 }

--- a/BibleProjector-WPF/MainWindow.xaml.cs
+++ b/BibleProjector-WPF/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace BibleProjector_WPF
 
             this.SetBinding(keyInputEventManagerProperty, new Binding("keyInputEventManager"));
             this.SetBinding(windowActivateChangedEventManagerProperty, new Binding("windowActivateChangedEventManager"));
+            this.SetBinding(activeSetterProperty, new Binding("activeSetter") { Mode = BindingMode.OneWay });
 
             setMinSize();
             setInnerContentSize();
@@ -200,6 +201,30 @@ namespace BibleProjector_WPF
         {
             get => (Event.WindowActivateChangedEventManager)GetValue(windowActivateChangedEventManagerProperty);
             set => SetValue(windowActivateChangedEventManagerProperty, value);
+        }
+
+        public static readonly DependencyProperty activeSetterProperty =
+        DependencyProperty.Register(
+            name: "activeSetter",
+            propertyType: typeof(bool),
+            ownerType: typeof(MainWindow),
+            typeMetadata: new PropertyMetadata(
+                (d, e) =>
+                {
+                    if ((bool)e.NewValue)
+                    {
+                        ((MainWindow)d).Topmost = true;
+                        ((MainWindow)d).Topmost = false;
+                        ((MainWindow)d).Activate();
+                    }
+                }
+                )
+            );
+
+        public bool activeSetter
+        {
+            get => (bool)GetValue(activeSetterProperty);
+            set => SetValue(activeSetterProperty, value);
         }
 
         private void EH_Window_Activated(object sender, EventArgs e)

--- a/BibleProjector-WPF/MainWindow.xaml.cs
+++ b/BibleProjector-WPF/MainWindow.xaml.cs
@@ -161,8 +161,7 @@ namespace BibleProjector_WPF
                 if (k.key == e.Key)
                     k.state = true;
 
-            if (!e.IsRepeat)
-                keyInputEventManager.invokeKeyInput(e.Key, true);
+            keyInputEventManager.invokeKeyInput(e.Key, true, e.IsRepeat);
         }
 
         private void EH_KeyUpCheck(object sender, KeyEventArgs e)
@@ -171,8 +170,7 @@ namespace BibleProjector_WPF
                 if (k.key == e.Key)
                     k.state = false;
 
-            if (!e.IsRepeat)
-                keyInputEventManager.invokeKeyInput(e.Key, false);
+            keyInputEventManager.invokeKeyInput(e.Key, false, e.IsRepeat);
         }
 
         private class TrackedKey
@@ -208,7 +206,7 @@ namespace BibleProjector_WPF
         {
             foreach (TrackedKey k in TrackedKeys) 
                 if (Keyboard.IsKeyDown(k.key) != k.state)
-                    keyInputEventManager.invokeKeyInput(k.key, Keyboard.IsKeyDown(k.key));
+                    keyInputEventManager.invokeKeyInput(k.key, Keyboard.IsKeyDown(k.key), false);
 
             windowActivateChangedEventManager.invoke(true);
         }

--- a/BibleProjector-WPF/ProgramStartEnd.cs
+++ b/BibleProjector-WPF/ProgramStartEnd.cs
@@ -155,7 +155,8 @@ namespace BibleProjector_WPF
                         new ViewModel.MainPage.VMOptionBar(),
                         new ViewModel.LyricViewModel(showStarter, songMan, reserveDataManager)),
                     keyInputEventManager,
-                    WACEventManager);
+                    WACEventManager,
+                    showStarter);
 
             loadingWindow.Dispatcher.BeginInvoke(
                 new Action<ViewModel.VMMainWindow>(loadingWindow.InitializeDone),

--- a/BibleProjector-WPF/Properties/AssemblyInfo.cs
+++ b/BibleProjector-WPF/Properties/AssemblyInfo.cs
@@ -51,5 +51,6 @@ using System.Windows;
 // 모든 값을 지정하거나 아래와 같이 '*'를 사용하여 빌드 번호 및 수정 번호를
 // 기본값으로 할 수 있습니다.
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("25.1.2")]
+[assembly: AssemblyFileVersion("25.1.2")]
+[assembly: AssemblyInformationalVersion("v25.1.2")]

--- a/BibleProjector-WPF/View/LyricControl.xaml
+++ b/BibleProjector-WPF/View/LyricControl.xaml
@@ -17,7 +17,7 @@
             <ColumnDefinition Width="76*"/>
         </Grid.ColumnDefinitions>
         <Grid Grid.Row="0">
-            <TabControl>
+            <TabControl SelectedIndex="{Binding TabSelectionIndex}">
                 <!--곡 선택-->
                 <TabItem Header="곡 선택">
                     <Grid>

--- a/BibleProjector-WPF/View/LyricControl.xaml
+++ b/BibleProjector-WPF/View/LyricControl.xaml
@@ -65,16 +65,14 @@
                                 <ColumnDefinition Width="70*"/>
                             </Grid.ColumnDefinitions>
                             <ComboBox Grid.Column="0" ItemsSource="{Binding LyricList}" DisplayMemberPath="songTitle"
-                                  SelectedItem="{Binding currentLyric}"
-                                  x:Name="LyricComboBox">
+                                  SelectedItem="{Binding currentLyric}">
                             </ComboBox>
                             <Button Grid.Column="2" Content="곡 삭제" IsEnabled="{Binding isDeleteButtonEnable}"
                             Click="DeleteButton_Click"/>
                         </Grid>
 
                         <TextBox Grid.Row="5" Grid.Column="1" HorizontalScrollBarVisibility="auto"
-                             Text="{Binding currentLyricTitle, UpdateSourceTrigger=PropertyChanged}" 
-                             LostFocus="TitleTextBox_LostFocus">
+                             Text="{Binding currentLyricTitle, UpdateSourceTrigger=LostFocus}">
                         </TextBox>
 
                         <TextBox 
@@ -83,8 +81,7 @@
                         AcceptsReturn="True" 
                         HorizontalScrollBarVisibility="Auto" 
                         VerticalScrollBarVisibility="auto" 
-                        Text="{Binding currentLyricContent, UpdateSourceTrigger=PropertyChanged}"
-                        LostFocus="ContentTextBox_LostFocus">
+                        Text="{Binding currentLyricContent, UpdateSourceTrigger=LostFocus}">
                         </TextBox>
                     </Grid>
                 </TabItem>

--- a/BibleProjector-WPF/View/LyricControl.xaml
+++ b/BibleProjector-WPF/View/LyricControl.xaml
@@ -154,13 +154,58 @@
 
                         <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AddLyricTitle}"/>
 
-                        <TextBox 
-                        Grid.Row="5" 
-                        Grid.Column="1" 
-                        AcceptsReturn="True" 
-                        HorizontalScrollBarVisibility="Auto" 
-                        VerticalScrollBarVisibility="auto"
-                        Text="{Binding AddLyricContent}"/>
+                        <Border
+                            Grid.Row="5" 
+                            Grid.Column="1"
+                            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                            BorderThickness="1">
+                            <Grid>
+                                <ScrollViewer
+                                    HorizontalScrollBarVisibility="Auto" 
+                                    VerticalScrollBarVisibility="Auto"
+                                    x:Name="ContentScrollViewer_AddLyric">
+                                    <TextBox 
+                                        BorderThickness="0"
+                                        AcceptsReturn="True" 
+                                        Text="{Binding AddLyricContent, UpdateSourceTrigger=PropertyChanged}"/>
+                                </ScrollViewer>
+                                <Border Width="{Binding ElementName=ContentScrollViewer_AddLyric, Path=ViewportWidth}"
+                                        HorizontalAlignment="Left">
+                                    <Button
+                                        Content="엔터 지우기"
+                                        FontSize="10"
+                                        FontWeight="Bold"
+                                        Padding="3,4"
+                                        Margin="0,5,5,0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Click="RemoveEnterButton_AddLyric_Click">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding isMultiLineDeleteButtonEnable_AddLyric}" Value="true">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding isMultiLineDeleteButtonEnable_AddLyric}" Value="false">
+                                                        <Setter Property="Visibility" Value="Hidden"/>
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Background" Value="#FFF06B2C"/>
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                        <Setter Property="BorderBrush" Value="Black"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                        <Setter Property="Background" Value="#3FF06B2C"/>
+                                                        <Setter Property="Foreground" Value="#7F000000"/>
+                                                        <Setter Property="BorderBrush" Value="#3F000000"/>
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
+                                </Border>
+                            </Grid>
+                        </Border>
                     </Grid>
                 </TabItem>
 
@@ -201,10 +246,59 @@
                         </Grid>
                         <TextBox Grid.Row="3" Grid.Column="1"
                                  Text="{Binding CurrentHymnPosition_Text}"></TextBox>
-                        <TextBox Grid.Row="5" Grid.Column="1"
-                                 AcceptsReturn="True"
-                                 Text="{Binding VerseContent, UpdateSourceTrigger=PropertyChanged}"
-                                 LostFocus="HymnContentTextBox_LostFocus"></TextBox>
+                        <Border
+                            Grid.Row="5" 
+                            Grid.Column="1"
+                            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                            BorderThickness="1">
+                            <Grid>
+                                <ScrollViewer
+                                    HorizontalScrollBarVisibility="Auto" 
+                                    VerticalScrollBarVisibility="Auto"
+                                    x:Name="ContentScrollViewer_Hymn">
+                                    <TextBox 
+                                        BorderThickness="0"
+                                        AcceptsReturn="True" 
+                                        Text="{Binding VerseContent, UpdateSourceTrigger=PropertyChanged}"
+                                        LostFocus="HymnContentTextBox_LostFocus"/>
+                                </ScrollViewer>
+                                <Border Width="{Binding ElementName=ContentScrollViewer_Hymn, Path=ViewportWidth}"
+                                        HorizontalAlignment="Left">
+                                    <Button
+                                        Content="엔터 지우기"
+                                        FontSize="10"
+                                        FontWeight="Bold"
+                                        Padding="3,4"
+                                        Margin="0,5,5,0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Click="RemoveEnterButton_Hymn_Click">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding isMultiLineDeleteButtonEnable_Hymn}" Value="true">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding isMultiLineDeleteButtonEnable_Hymn}" Value="false">
+                                                        <Setter Property="Visibility" Value="Hidden"/>
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Background" Value="#FFF06B2C"/>
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                        <Setter Property="BorderBrush" Value="Black"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                        <Setter Property="Background" Value="#3FF06B2C"/>
+                                                        <Setter Property="Foreground" Value="#7F000000"/>
+                                                        <Setter Property="BorderBrush" Value="#3F000000"/>
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
+                                </Border>
+                            </Grid>
+                        </Border>
                     </Grid>
                 </TabItem>
             </TabControl>

--- a/BibleProjector-WPF/View/LyricControl.xaml
+++ b/BibleProjector-WPF/View/LyricControl.xaml
@@ -75,14 +75,59 @@
                              Text="{Binding currentLyricTitle, UpdateSourceTrigger=LostFocus}">
                         </TextBox>
 
-                        <TextBox 
-                        Grid.Row="7" 
-                        Grid.Column="1" 
-                        AcceptsReturn="True" 
-                        HorizontalScrollBarVisibility="Auto" 
-                        VerticalScrollBarVisibility="auto" 
-                        Text="{Binding currentLyricContent, UpdateSourceTrigger=LostFocus}">
-                        </TextBox>
+                        <Border
+                            Grid.Row="7" 
+                            Grid.Column="1"
+                            BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                            BorderThickness="1">
+                            <Grid>
+                                <ScrollViewer
+                                    HorizontalScrollBarVisibility="Auto" 
+                                    VerticalScrollBarVisibility="Auto"
+                                    x:Name="ContentScrollViewer">
+                                    <TextBox 
+                                        BorderThickness="0"
+                                        AcceptsReturn="True" 
+                                        Text="{Binding currentLyricContent, UpdateSourceTrigger=PropertyChanged}"
+                                        LostFocus="LyricContentTextBox_LostFocus"/>
+                                </ScrollViewer>
+                                <Border Width="{Binding ElementName=ContentScrollViewer, Path=ViewportWidth}"
+                                        HorizontalAlignment="Left">
+                                    <Button
+                                        Content="엔터 지우기"
+                                        FontSize="10"
+                                        FontWeight="Bold"
+                                        Padding="3,4"
+                                        Margin="0,5,5,0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Click="RemoveEnterButton_Click">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding isMultiLineDeleteButtonEnable}" Value="true">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding isMultiLineDeleteButtonEnable}" Value="false">
+                                                        <Setter Property="Visibility" Value="Hidden"/>
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Background" Value="#FFF06B2C"/>
+                                                        <Setter Property="Foreground" Value="Black"/>
+                                                        <Setter Property="BorderBrush" Value="Black"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="False">
+                                                        <Setter Property="Background" Value="#3FF06B2C"/>
+                                                        <Setter Property="Foreground" Value="#7F000000"/>
+                                                        <Setter Property="BorderBrush" Value="#3F000000"/>
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
+                                </Border>
+                            </Grid>
+                        </Border>
                     </Grid>
                 </TabItem>
 

--- a/BibleProjector-WPF/View/LyricControl.xaml.cs
+++ b/BibleProjector-WPF/View/LyricControl.xaml.cs
@@ -52,16 +52,6 @@ namespace BibleProjector_WPF
             VM_LyricViewModel.RunDelete();
         }
 
-        void TitleTextBox_LostFocus(object sender, RoutedEventArgs e)
-        {
-            VM_LyricViewModel.RunCompleteModify();
-        }
-
-        void ContentTextBox_LostFocus(object sender, RoutedEventArgs e)
-        {
-            VM_LyricViewModel.RunCompleteModify();
-        }
-
         // =========================== 곡 추가 탭
 
         void AddButton_Click(object sender, RoutedEventArgs e)

--- a/BibleProjector-WPF/View/LyricControl.xaml.cs
+++ b/BibleProjector-WPF/View/LyricControl.xaml.cs
@@ -69,11 +69,21 @@ namespace BibleProjector_WPF
             VM_LyricViewModel.RunAdd();
         }
 
+        private void RemoveEnterButton_AddLyric_Click(object sender, RoutedEventArgs e)
+        {
+            VM_LyricViewModel.RunRemoveDoubleEnter_AddLyric();
+        }
+
         // =========================== 찬송가 탭
 
         void HymnContentTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
             VM_LyricViewModel.RunApplyHymnModify();
+        }
+
+        private void RemoveEnterButton_Hymn_Click(object sender, RoutedEventArgs e)
+        {
+            VM_LyricViewModel.RunRemoveDoubleEnter_Hymn();
         }
 
         // ======================================================= 출력 처리 ======================================================

--- a/BibleProjector-WPF/View/LyricControl.xaml.cs
+++ b/BibleProjector-WPF/View/LyricControl.xaml.cs
@@ -52,6 +52,16 @@ namespace BibleProjector_WPF
             VM_LyricViewModel.RunDelete();
         }
 
+        private void LyricContentTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            VM_LyricViewModel.submitModifyingCurrentContent();
+        }
+
+        private void RemoveEnterButton_Click(object sender, RoutedEventArgs e)
+        {
+            VM_LyricViewModel.RunRemoveDoubleEnter();
+        }
+
         // =========================== 곡 추가 탭
 
         void AddButton_Click(object sender, RoutedEventArgs e)

--- a/BibleProjector-WPF/View/MainPage/ControlView.xaml
+++ b/BibleProjector-WPF/View/MainPage/ControlView.xaml
@@ -15,8 +15,22 @@
         <!--상/하단 페이지 컨트롤러-->
         <ContentControl Grid.Row="0" Content="{Binding VM_ShowControler_top}"
                         KeyboardNavigation.DirectionalNavigation="Contained"/>
-        <ContentControl Grid.Row="2" Content="{Binding VM_ShowControler_bottom}"
-                        KeyboardNavigation.DirectionalNavigation="Contained"/>
+        <ItemsControl Grid.Row="2" 
+                      ItemsSource="{Binding VM_ShowControler_bottoms}"
+                      KeyboardNavigation.DirectionalNavigation="Contained">
+            <ItemsControl.ItemContainerStyle>
+                <Style TargetType="ContentPresenter">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding isShowing}" Value="true">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding isShowing}" Value="false">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ItemsControl.ItemContainerStyle>
+        </ItemsControl>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>

--- a/BibleProjector-WPF/View/MainPage/MainView.xaml
+++ b/BibleProjector-WPF/View/MainPage/MainView.xaml
@@ -21,7 +21,9 @@
 
         <TabControl Grid.Row="1" Grid.Column="1">
             <!--통합 조작 페이지-->
-            <TabItem Header="통합검색 및 예약" Content="{Binding VM_MainControl}"/>
+            <TabItem Header="통합검색 및 예약">
+                <ContentControl Content="{Binding VM_MainControl}"/>
+            </TabItem>
 
             <!--자료 수정 페이지-->
             <TabItem Header="자료 수정">

--- a/BibleProjector-WPF/View/MainPage/ReserverListView.xaml
+++ b/BibleProjector-WPF/View/MainPage/ReserverListView.xaml
@@ -74,7 +74,8 @@
                             <Setter Property="Padding" Value="0"/>
                             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                             <EventSetter Event="MouseMove" Handler="EH_GetMouseMove"/>
-                            <EventSetter Event="MouseDoubleClick" Handler="EH_ItemDoubleClick"/>
+                            <EventSetter Event="PreviewMouseDown" Handler="EH_ItemDoubleClick_Trigger"/>
+                            <EventSetter Event="PreviewMouseUp" Handler="EH_ItemDoubleClick_Performer"/>
                             <EventSetter Event="PreviewKeyDown" Handler="EH_ListBoxItem_PreviewKeyDown"/>
                             <EventSetter Event="PreviewKeyUp" Handler="EH_ListBoxItem_PreviewKeyUp"/>
                             <Style.Triggers>

--- a/BibleProjector-WPF/View/MainPage/ReserverListView.xaml
+++ b/BibleProjector-WPF/View/MainPage/ReserverListView.xaml
@@ -39,7 +39,6 @@
                     Padding="5,0"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                     AllowDrop="true"
-                    PreviewMouseUp="EH_ReserveListBox_Focus_PreviewMouseUp"
                     
                     PreviewMouseWheel="EH_ScrollByWheel"
                     

--- a/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
+++ b/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
@@ -396,14 +396,21 @@ namespace BibleProjector_WPF.View.MainPage
 
         private void EH_ReserveListBox_Focus_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
-            if (ReserveListBox.SelectedIndex == -1 && ReserveListBox.Items.Count > 0) 
-            {
-                ReserveListBox.Focus();
-                ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromIndex(0)).Focus();
-            }
-            else if (ReserveListBox.SelectedIndex >= 0)
+            if (ReserveListBox.SelectedItem != null
+                && getViewTypeProperty(ReserveListBox.SelectedItem) == ReserveViewType.NormalItem) 
             {
                 ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromIndex(ReserveListBox.SelectedIndex)).Focus();
+            }
+            else
+            {
+                for (int i = 0; i < ReserveListBox.Items.Count; i++)
+                {
+                    if (getViewTypeProperty(ReserveListBox.Items[i]) == ReserveViewType.NormalItem)
+                    {
+                        ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromIndex(i)).Focus();
+                        break;
+                    }
+                }
             }
         }
     }

--- a/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
+++ b/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
@@ -398,22 +398,31 @@ namespace BibleProjector_WPF.View.MainPage
 
         private void EH_ReserveListBox_Focus_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
-            if (ReserveListBox.SelectedItem != null
-                && getViewTypeProperty(ReserveListBox.SelectedItem) == ReserveViewType.NormalItem) 
+            ListBoxItem mustFocusedItem = null;
+
+            foreach (object item in ReserveListBox.SelectedItems)
             {
-                ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromIndex(ReserveListBox.SelectedIndex)).Focus();
-            }
-            else
-            {
-                for (int i = 0; i < ReserveListBox.Items.Count; i++)
+                if (getViewTypeProperty(item) == ReserveViewType.NormalItem)
                 {
-                    if (getViewTypeProperty(ReserveListBox.Items[i]) == ReserveViewType.NormalItem)
+                    mustFocusedItem = (ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromItem(item);
+                    break;
+                }
+            }
+
+            if (mustFocusedItem == null)
+            {
+                foreach (object item in ReserveListBox.Items)
+                {
+                    if (getViewTypeProperty(item) == ReserveViewType.NormalItem)
                     {
-                        ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromIndex(i)).Focus();
+                        mustFocusedItem = (ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromItem(item);
                         break;
                     }
                 }
             }
+
+            if (mustFocusedItem != null)
+                mustFocusedItem.Focus();
         }
     }
 }

--- a/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
+++ b/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
@@ -387,6 +387,8 @@ namespace BibleProjector_WPF.View.MainPage
             ReserveListBox.UpdateLayout();
             foreach (object item in selections)
                 ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromItem(item)).IsSelected = true;
+            if (selections.Count > 0)
+                ((ListBoxItem)ReserveListBox.ItemContainerGenerator.ContainerFromItem(selections[0])).Focus();
 
             DragPreviewItem.Visibility = Visibility.Hidden;
             DropPreviewItem.Visibility = Visibility.Collapsed;

--- a/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
+++ b/BibleProjector-WPF/View/MainPage/ReserverListView.xaml.cs
@@ -250,12 +250,37 @@ namespace BibleProjector_WPF.View.MainPage
          *                 Item DoubleClick
          =======================================================*/
 
-        private void EH_ItemDoubleClick(object sender, MouseButtonEventArgs e)
+        // 변수 도입 사유 :
+        //   더블클릭시 새 자막을 표시하면서 ShowControler에 포커싱되어야 하므로
+        //   더블클릭의 MouseUp 이벤트에 의한 예약 UI의 포커싱 처리는 무시되어야 함.
+        //
+        //   그러나 DoubleClick 이벤트의 발생 시점 상,
+        //   예약 UI의 포커싱 요청이 모두 끝나기 전에 처리가 되므로
+        //   다른 UI에서 거는 포커싱 요청이 무시됨.
+        //
+        //   따라서 MouseUp 시점에서 최종 더블클릭 처리를 진행하여,
+        //   외부와의 간섭을 최소화 하도록 구성함.
+        //   이 과정에서 내부 포커싱 로직을 무시하고 더블클릭 상태를 위임할 수 있도록
+        //   두 변수를 도입하게 됨.
+        private bool ignoreFocusing = false;
+        private bool doDoubleClick = false;
+
+        private void EH_ItemDoubleClick_Trigger(object sender, MouseButtonEventArgs e)
         {
-            Keyboard.ClearFocus();
-            FocusManager.SetFocusedElement(FocusManager.GetFocusScope((DependencyObject)sender), null);
-            ItemShowStartCommand.Execute(((ListBoxItem)sender).DataContext);
-            e.Handled = true;
+            if (e.ClickCount > 1)
+            {
+                ignoreFocusing = true;
+                doDoubleClick = true;
+            }
+        }
+
+        private void EH_ItemDoubleClick_Performer(object sender, MouseButtonEventArgs e)
+        {
+            if (doDoubleClick)
+            {
+                doDoubleClick = false;
+                ItemShowStartCommand.Execute(((ListBoxItem)sender).DataContext);
+            }
         }
 
         /*=======================================================
@@ -398,6 +423,12 @@ namespace BibleProjector_WPF.View.MainPage
 
         private void EH_ReserveListBox_Focus_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
+            if (ignoreFocusing)
+            {
+                ignoreFocusing = false;
+                return;
+            }
+
             ListBoxItem mustFocusedItem = null;
 
             foreach (object item in ReserveListBox.SelectedItems)

--- a/BibleProjector-WPF/View/MainPage/ShowControler.xaml
+++ b/BibleProjector-WPF/View/MainPage/ShowControler.xaml
@@ -183,21 +183,30 @@
                         </Border>
                     </DataTemplate>
                 </ListBox.Resources>
-                <ListBox.Style>
-                    <Style TargetType="ListBox">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding ContentType}" Value="{x:Static home:ShowContentType.Bible}">
-                                <Setter Property="ItemTemplate" Value="{StaticResource ResourceKey=StringItem}"/>
-                            </DataTrigger>
-                            <DataTrigger Binding="{Binding ContentType}" Value="{x:Static home:ShowContentType.Song}">
-                                <Setter Property="ItemTemplate" Value="{StaticResource ResourceKey=StringItem}"/>
-                            </DataTrigger>
-                            <DataTrigger Binding="{Binding ContentType}" Value="{x:Static home:ShowContentType.PPT}">
-                                <Setter Property="ItemTemplate" Value="{StaticResource ResourceKey=ImageItem}"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </ListBox.Style>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <ContentControl Content="{Binding}">
+                            <ContentControl.Style>
+                                <Style TargetType="ContentControl">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=DataContext.ContentType}"
+                                                     Value="{x:Static home:ShowContentType.Bible}">
+                                            <Setter Property="ContentTemplate" Value="{StaticResource ResourceKey=StringItem}"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=DataContext.ContentType}"
+                                                     Value="{x:Static home:ShowContentType.Song}">
+                                            <Setter Property="ContentTemplate" Value="{StaticResource ResourceKey=StringItem}"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=DataContext.ContentType}"
+                                                     Value="{x:Static home:ShowContentType.PPT}">
+                                            <Setter Property="ContentTemplate" Value="{StaticResource ResourceKey=ImageItem}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ContentControl.Style>
+                        </ContentControl>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
                         <StackPanel Orientation="Horizontal"

--- a/BibleProjector-WPF/View/MainPage/ShowControler.xaml.cs
+++ b/BibleProjector-WPF/View/MainPage/ShowControler.xaml.cs
@@ -171,6 +171,22 @@ namespace BibleProjector_WPF.View.MainPage
 
         private void EH_OffUnusedKeyInput(object sender, KeyEventArgs e)
         {
+            // <이 코드가 맡는 역할 명세>
+            //
+            // ● 역할
+            //   이 코드는 화살표 키로 이동시 2중 이동하는 문제를 다룹니다.
+            //
+            // ● 원인 분석
+            //   1. 키 조작에 대한 처리는 메인에서 진행함.
+            //   2. 키 입력 이벤트는 [상위 뷰 -> 하위 뷰] 순서로 진행됨.
+            //   3. 만약 이 뷰에서 키 입력을 받아들이면,
+            //        1) 메인 뷰의 키 입력으로 이미 페이지를 이동한 상태에서
+            //        2) ListBox도 키 입력을 받아 항목을 이동하면서
+            //      2중 이동이 발생함
+            //
+            // ● 처리
+            //   이 뷰의 화살표 키 입력은 무시함으로써 ListBox의 화살표 키 인식을 막도록 함.
+
             if (e.Key == Key.Left
                 || e.Key == Key.Down
                 || e.Key == Key.Right

--- a/BibleProjector-WPF/View/ProgramStartLoading.xaml.cs
+++ b/BibleProjector-WPF/View/ProgramStartLoading.xaml.cs
@@ -28,7 +28,16 @@ namespace BibleProjector_WPF
         public string loadingText { get; private set; } = "";
         private const double MAX_PROGRESS_BAR_LENGTH = 94.0;
         public double loadingBarLength { get; private set; } = 0;
-        public string Version { get; } = "v25.1.1";
+        public string Version { get; } = getProgramVersion();
+
+        private static string getProgramVersion()
+        {
+            System.Reflection.Assembly assembly = 
+                System.Reflection.Assembly
+                .GetExecutingAssembly();
+            return System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location)
+                .ProductVersion;
+        }
 
         public ProgramStartLoading()
         {

--- a/BibleProjector-WPF/ViewModel/LyricViewModel.cs
+++ b/BibleProjector-WPF/ViewModel/LyricViewModel.cs
@@ -166,7 +166,7 @@ namespace BibleProjector_WPF.ViewModel
             set 
             { 
                 _AddLyricContent = value;
-                isMultiLineDeleteButtonEnable_AddLyric = _AddLyricContent.Contains("\r\n\r\n");
+                isMultiLineDeleteButtonEnable_AddLyric = module.StringModifier.hasMultiLinefeeds(_AddLyricContent);
                 OnPropertyChanged(nameof(isMultiLineDeleteButtonEnable_AddLyric));
             } 
         }
@@ -279,7 +279,7 @@ namespace BibleProjector_WPF.ViewModel
             }
             OnPropertyChanged(nameof(VerseContent));
 
-            isMultiLineDeleteButtonEnable_Hymn = VerseContent_in.Contains("\r\n\r\n");
+            isMultiLineDeleteButtonEnable_Hymn = module.StringModifier.hasMultiLinefeeds(VerseContent_in);
             OnPropertyChanged(nameof(isMultiLineDeleteButtonEnable_Hymn));
         }
 
@@ -511,7 +511,7 @@ namespace BibleProjector_WPF.ViewModel
             }
             OnPropertyChanged(nameof(currentLyricContent));
 
-            isMultiLineDeleteButtonEnable = currentLyricContent_in.Contains("\r\n\r\n");
+            isMultiLineDeleteButtonEnable = module.StringModifier.hasMultiLinefeeds(currentLyricContent_in);
             OnPropertyChanged(nameof(isMultiLineDeleteButtonEnable));
         }
 

--- a/BibleProjector-WPF/ViewModel/LyricViewModel.cs
+++ b/BibleProjector-WPF/ViewModel/LyricViewModel.cs
@@ -47,6 +47,9 @@ namespace BibleProjector_WPF.ViewModel
 
         // =================================== 공용
 
+        // 탭 표시 인덱스
+        public int TabSelectionIndex { get; set; }
+
         // 출력 곡 선택값
         private module.Data.SongData SelectedLyric_in;
         public module.Data.SongData SelectedLyric
@@ -336,6 +339,13 @@ namespace BibleProjector_WPF.ViewModel
                     SearchText = lastSearchPattern;
                 }
                 setCurrentLyric(newLyric);
+
+                AddLyricTitle = "";
+                OnPropertyChanged(nameof(AddLyricTitle));
+                AddLyricContent = "";
+                OnPropertyChanged(nameof(AddLyricContent));
+                TabSelectionIndex = 0;
+                OnPropertyChanged(nameof(TabSelectionIndex));
             }
         }
 

--- a/BibleProjector-WPF/ViewModel/LyricViewModel.cs
+++ b/BibleProjector-WPF/ViewModel/LyricViewModel.cs
@@ -332,6 +332,7 @@ namespace BibleProjector_WPF.ViewModel
             if (newLyric != null)
             {
                 songManager.AddSongInOrder(newLyric);
+                LyricList.ResetBindings(); // BindingList 내부의 각 항목들에 대한 갱신은 다시 명시적으로 처리해야 함.
 
                 if (lastSearchPattern != null)
                 {
@@ -359,6 +360,7 @@ namespace BibleProjector_WPF.ViewModel
                 return;
 
             songManager.DeleteSongItem(deleteItem);
+            LyricList.ResetBindings(); // BindingList 내부의 각 항목들에 대한 갱신은 다시 명시적으로 처리해야 함.
 
             if (lastSearchPattern != null)
             {
@@ -482,6 +484,24 @@ namespace BibleProjector_WPF.ViewModel
 
                     if (lastSearchPattern != null)
                         refreshSearchItem(currentLyric, lastSearchPattern);
+
+                    LyricList.ResetBindings(); // BindingList 내부의 각 항목들에 대한 갱신은 다시 명시적으로 처리해야 함.
+                    // 표시되는 현재 선택값도 갱신이 필요하므로 진행.
+                    // Nested Property 형태의 바인딩이므로 내부 속성에 대한 onPropertyChanged 이벤트가 필요하나
+                    // 과거 설계상 이를 생략해둔 상태이므로
+                    // 대신하여 객체 자체에 대해 UI를 갱신함.
+                    module.Data.SongData updatedLyric = currentLyric;
+                    currentLyric_in = null;
+                    OnPropertyChanged(nameof(currentLyric));
+                    currentLyric_in = updatedLyric;
+                    OnPropertyChanged(nameof(currentLyric));
+                    if (SelectedLyric == updatedLyric)
+                    {
+                        SelectedLyric_in = null;
+                        OnPropertyChanged(nameof(SelectedLyric));
+                        SelectedLyric_in = updatedLyric;
+                        OnPropertyChanged(nameof(SelectedLyric));
+                    }
                 }
             }
             else

--- a/BibleProjector-WPF/ViewModel/MainPage/VMControlPage.cs
+++ b/BibleProjector-WPF/ViewModel/MainPage/VMControlPage.cs
@@ -47,7 +47,7 @@ namespace BibleProjector_WPF.ViewModel.MainPage
 
             keyInputEventManager.KeyDownWithRepeat += KeyInputTask;
 
-            showStarter.ShowStartEvent += WhenShowStarted;
+            showStarter.ShowStartPreparing += WhenShowStarted;
         }
 
         // ========== Show Controller Changing ===========

--- a/BibleProjector-WPF/ViewModel/MainPage/VMControlPage.cs
+++ b/BibleProjector-WPF/ViewModel/MainPage/VMControlPage.cs
@@ -13,7 +13,7 @@ namespace BibleProjector_WPF.ViewModel.MainPage
 
         ViewModel[] ShowController;
         public ViewModel VM_ShowControler_top { get; }
-        public ViewModel VM_ShowControler_bottom { get; private set; }
+        public ObservableCollection<ViewModel> VM_ShowControler_bottoms { get; private set; }
         public ViewModel VM_BibleSeletion { get; }
         public ViewModel VM_SearchControl { get; }
         public ViewModel VM_ReserveList { get; }
@@ -37,11 +37,13 @@ namespace BibleProjector_WPF.ViewModel.MainPage
         {
             this.ShowController = ShowControlers;
             this.VM_ShowControler_top = ShowControlers[2];
-            this.VM_ShowControler_bottom = ShowControlers[0];
+            this.VM_ShowControler_bottoms = new ObservableCollection<ViewModel>() { ShowControlers[0], ShowControlers[1] };
             this.VM_BibleSeletion = bibleSelection;
             this.VM_SearchControl = searchControl;
             this.VM_ReserveList = reserveList;
             this.ExternPPTEditButtons = externPPTEditButtonVMs;
+
+            setBottomShowController(0, false);
 
             keyInputEventManager.KeyDownWithRepeat += KeyInputTask;
 
@@ -52,12 +54,10 @@ namespace BibleProjector_WPF.ViewModel.MainPage
 
         void WhenShowStarted(object sender, Event.ShowStartEventArgs e)
         {
-            if (e.showData.getDataType() == ShowContentType.Bible
-                && VM_ShowControler_bottom != ShowController[0])
-                changeBottomShowController(0);
-            else if (e.showData.getDataType() == ShowContentType.Song
-                && VM_ShowControler_bottom != ShowController[1])
-                changeBottomShowController(1);
+            if (e.showData.getDataType() == ShowContentType.Bible)
+                setBottomShowController(0, false); // Bible 컨트롤러가 0에 연결되는 것은 너무 변경에 취약함 (개선 필요)
+            else if (e.showData.getDataType() == ShowContentType.Song)
+                setBottomShowController(1, false); // Song 컨트롤러가 1에 연결되는 것은 너무 변경에 취약함 (개선 필요)
         }
 
         void KeyInputTask(System.Windows.Input.Key key, bool isDown, bool isRepeat)
@@ -70,26 +70,40 @@ namespace BibleProjector_WPF.ViewModel.MainPage
                     && isDown
                     && !isRepeat)
                 {
-                    if (VM_ShowControler_bottom == ShowController[0])
-                        changeBottomShowController(1);
-                    else
-                        changeBottomShowController(0);
+                    setNextBottomShowController(true);
                 }
             }
         }
 
-        void changeBottomShowController(int index)
+        private int currentSelection = -1;
+
+        private void setNextBottomShowController(bool invokeViewModelChanged)
+        {
+            setBottomShowController(
+                (currentSelection + 1) % VM_ShowControler_bottoms.Count,
+                invokeViewModelChanged);
+        }
+ 
+        private void setBottomShowController(int index, bool invokeViewModelChanged)
         {
             if (index < 0 || index >= ShowController.Length)
                 throw new Exception("잘못된 쇼 컨트롤러 인덱스 : " + index + "번 컨트롤러는 없습니다! / " + ShowController.Length);
 
-            if (VM_ShowControler_bottom != ShowController[index])
+            if (currentSelection != index)
             {
-                ((VMShowControler)VM_ShowControler_bottom).hasFocus = false;
-                VM_ShowControler_bottom = ShowController[index];
+                if (0 <= currentSelection && currentSelection < VM_ShowControler_bottoms.Count)
+                {
+                    ((VMShowControler)VM_ShowControler_bottoms[currentSelection]).hasFocus = false;
+                    ((VMShowControler)VM_ShowControler_bottoms[currentSelection]).hide();
+                }
+                ((VMShowControler)VM_ShowControler_bottoms[index]).show();
+                currentSelection = index;
             }
-            OnPropertyChanged("VM_ShowControler_bottom");
-            ((VMShowControler)VM_ShowControler_bottom).doViewModelChanged();
+
+            if (invokeViewModelChanged)
+            {
+                ((VMShowControler)VM_ShowControler_bottoms[index]).doViewModelChanged();
+            }
         }
     }
 }

--- a/BibleProjector-WPF/ViewModel/MainPage/VMControlPage.cs
+++ b/BibleProjector-WPF/ViewModel/MainPage/VMControlPage.cs
@@ -43,7 +43,7 @@ namespace BibleProjector_WPF.ViewModel.MainPage
             this.VM_ReserveList = reserveList;
             this.ExternPPTEditButtons = externPPTEditButtonVMs;
 
-            keyInputEventManager.KeyDown += KeyInputTask;
+            keyInputEventManager.KeyDownWithRepeat += KeyInputTask;
 
             showStarter.ShowStartEvent += WhenShowStarted;
         }
@@ -60,14 +60,15 @@ namespace BibleProjector_WPF.ViewModel.MainPage
                 changeBottomShowController(1);
         }
 
-        void KeyInputTask(System.Windows.Input.Key key, bool isDown)
+        void KeyInputTask(System.Windows.Input.Key key, bool isDown, bool isRepeat)
         {
             if (IsLoaded(null)) {
                 foreach (VMShowControler vm in ShowController)
-                    vm.keyInputed(key, isDown);
+                    vm.keyInputed(key, isDown, isRepeat);
 
                 if (key == System.Windows.Input.Key.CapsLock
-                    && isDown)
+                    && isDown
+                    && !isRepeat)
                 {
                     if (VM_ShowControler_bottom == ShowController[0])
                         changeBottomShowController(1);

--- a/BibleProjector-WPF/ViewModel/MainPage/VMShowControler.cs
+++ b/BibleProjector-WPF/ViewModel/MainPage/VMShowControler.cs
@@ -30,17 +30,17 @@ namespace BibleProjector_WPF.ViewModel.MainPage
 
         public ObservableCollection<VMShowItem> Pages { get; set; }
         int _CurrentPageIndex;
-        public int CurrentPageIndex 
-        { 
-            get 
-            { 
-                return _CurrentPageIndex; 
-            } 
-            set 
+        public int CurrentPageIndex
+        {
+            get
+            {
+                return _CurrentPageIndex;
+            }
+            set
             {
                 if (_CurrentPageIndex != value)
                     MovePage(value);
-            } 
+            }
         }
 
         public bool DisplayButtonState { get; set; } = false;
@@ -149,7 +149,7 @@ namespace BibleProjector_WPF.ViewModel.MainPage
         {
             if (deleteAll)
                 setMoveNumber(0);
-            else if (moveNumber != 0) 
+            else if (moveNumber != 0)
             {
                 if (moveNumber / 10 == 0)
                     setMoveNumber(0);
@@ -158,9 +158,9 @@ namespace BibleProjector_WPF.ViewModel.MainPage
             }
         }
 
-        // =================================
+        // ============ 일반 키 입력 ============
 
-        int KeyToNum(Key key)
+        private int KeyToNum(Key key)
         {
             if (key >= Key.D0 && key <= Key.D9)
                 return (key - Key.D0);
@@ -170,61 +170,66 @@ namespace BibleProjector_WPF.ViewModel.MainPage
                 return -1;
         }
 
-        public void keyInputed(Key inputKey, bool isDown)
+        public void keyInputed(Key inputKey, bool isDown, bool isRepeat)
         {
-            if (inputKey == Key.LeftCtrl
-                || inputKey == Key.RightCtrl)
+            if (!isRepeat)
             {
-                if (isDown)
+                if (inputKey == Key.LeftCtrl
+                    || inputKey == Key.RightCtrl)
                 {
-                    doFastPass = true;
+                    doFastPass = isDown;
                     OnPropertyChanged(nameof(doFastPass));
-                }
-                else
-                {
-                    doFastPass = false;
-                    OnPropertyChanged(nameof(doFastPass));
+                    return;
                 }
             }
 
             if (hasFocus && isDown)
             {
+                if (inputKey == Key.Up || inputKey == Key.Right)
+                {
+                    GoNextPage(doFastPass);
+                    return;
+                }
+
+                if (inputKey == Key.Down || inputKey == Key.Left)
+                {
+                    GoPreviousPage(doFastPass);
+                    return;
+                }
+            }
+
+            if (hasFocus && isDown && !isRepeat)
+            {
                 if (inputKey >= Key.D0 && inputKey <= Key.D9
-                    || inputKey >= Key.NumPad0 && inputKey <= Key.NumPad9) 
+                    || inputKey >= Key.NumPad0 && inputKey <= Key.NumPad9)
                 {
                     addMoveNumber(KeyToNum(inputKey));
+                    return;
                 }
-                else
+
+                if (inputKey == Key.Delete
+                    || inputKey == Key.Back)
                 {
-                    switch (inputKey)
+                    removeMoveNumber(true);
+                    return;
+                }
+
+                if (inputKey == Key.Enter) 
+                {
+                    if (Pages != null
+                        && 1 <= moveNumber && moveNumber <= Pages.Count)
                     {
-                        case Key.Enter:
-                            if (moveNumber != 0
-                                && Pages != null
-                                && 1 <= moveNumber && moveNumber <= Pages.Count)
-                            {
-                                MovePage(moveNumber - 1);
-                                removeMoveNumber(true);
-                            }
-                            else
-                                GoNextPage(doFastPass);
-                            break;
-                        case Key.Up:
-                        case Key.Right:
-                            GoNextPage(doFastPass);
-                            break;
-                        case Key.Down:
-                        case Key.Left:
-                            GoPreviousPage(doFastPass);
-                            break;
-                        case Key.Delete:
-                        case Key.Back:
-                            removeMoveNumber(true);
-                            break;
+                        MovePage(moveNumber - 1);
+                        removeMoveNumber(true);
                     }
+                    else
+                        GoNextPage(doFastPass);
+                    return;
                 }
             }
         }
+
+        // ==================================
 
         public void newShowStart(module.Data.ShowData data)
         {

--- a/BibleProjector-WPF/ViewModel/MainPage/VMShowControler.cs
+++ b/BibleProjector-WPF/ViewModel/MainPage/VMShowControler.cs
@@ -55,6 +55,8 @@ namespace BibleProjector_WPF.ViewModel.MainPage
         private bool activation;
         public bool isActive { get { return hasFocus && activation; } }
 
+        public bool isShowing { get; private set; } = false;
+
         public bool doFastPass { get; private set; } = false;
 
         // 애니메이션 효과
@@ -100,9 +102,9 @@ namespace BibleProjector_WPF.ViewModel.MainPage
 
         public void doViewModelChanged()
         {
-            DoAnimation = true;
-            OnPropertyChanged("DoAnimation");
             DoAnimation = false;
+            OnPropertyChanged("DoAnimation");
+            DoAnimation = true;
             OnPropertyChanged("DoAnimation");
 
             hasFocus = true;
@@ -116,6 +118,18 @@ namespace BibleProjector_WPF.ViewModel.MainPage
                 activation = isActive;
                 OnPropertyChanged(nameof(isActive));
             }
+        }
+
+        public void show()
+        {
+            this.isShowing = true;
+            OnPropertyChanged(nameof(this.isShowing));
+        }
+
+        public void hide()
+        {
+            this.isShowing = false;
+            OnPropertyChanged(nameof(this.isShowing));
         }
 
         // =========== 숫자 이동 입력 ===========

--- a/BibleProjector-WPF/ViewModel/VMMainWindow.cs
+++ b/BibleProjector-WPF/ViewModel/VMMainWindow.cs
@@ -6,18 +6,28 @@ using System.Threading.Tasks;
 
 namespace BibleProjector_WPF.ViewModel
 {
-    public class VMMainWindow
+    public class VMMainWindow : ViewModel
     {
         public ViewModel VM_Main { get; set; }
 
         public Event.KeyInputEventManager keyInputEventManager { get; set; }
         public Event.WindowActivateChangedEventManager windowActivateChangedEventManager { get; set; }
+        public bool activeSetter { get; private set; } = false;
 
-        public VMMainWindow(ViewModel vmMain, Event.KeyInputEventManager keyInputEventManager, Event.WindowActivateChangedEventManager windowActivateChangedEventManager)
+        public VMMainWindow(ViewModel vmMain, Event.KeyInputEventManager keyInputEventManager, Event.WindowActivateChangedEventManager windowActivateChangedEventManager, module.ShowStarter showStarter)
         {
             this.VM_Main = vmMain;
             this.keyInputEventManager = keyInputEventManager;
             this.windowActivateChangedEventManager = windowActivateChangedEventManager;
+            showStarter.ShowStartTaskDone += showStarted;
+        }
+
+        private void showStarted(object sender, EventArgs e)
+        {
+            activeSetter = true;
+            OnPropertyChanged(nameof(activeSetter));
+            activeSetter = false;
+            OnPropertyChanged(nameof(activeSetter));
         }
     }
 }

--- a/BibleProjector-WPF/module/Powerpoint.cs
+++ b/BibleProjector-WPF/module/Powerpoint.cs
@@ -1487,8 +1487,6 @@ namespace BibleProjector_WPF
                 TopMost();
             }
 
-            System.Threading.Mutex slideControlMutex = new System.Threading.Mutex();
-
             public void goToSlide(int slideIndex)
             {
                 if (slideIndex < 1)
@@ -1498,20 +1496,50 @@ namespace BibleProjector_WPF
                 else
                     currentSlideNum = slideIndex;
 
-                new System.Threading.Thread(threadedSlideMover)
-                    .Start(currentSlideNum);
+                requestMovingSlide(currentSlideNum);
             }
 
-            private void threadedSlideMover(object slideIndex)
-            {
-                slideControlMutex.WaitOne();
-                
-                if (currentSlideNum == (int)slideIndex)
-                    if (SlideWindow != null)
-                        SlideWindow.View.GotoSlide((int)slideIndex);
+            // ========================== Threaded Slide Moving ==========================
 
+            // 애니메이션이 포함된 슬라이드 이동시 UI가 잠시 멈추게 되는데 (UI는 동기(sync) 상태)
+            // 이때, 빠르게 UI를 조작하면 이상한 번호로 슬라이드가 이동되는 문제가 발생함.
+            // 따라서 비동기 로직으로 구성하기 위해, 실제 슬라이드의 이동은 스레딩을 통해 처리함.
+
+            System.Threading.Mutex slideControlMutex = new System.Threading.Mutex();
+            private (bool isRequested, int slideIndex) slideMoveRequest = (false, -1);
+            private System.Threading.Thread slideControlThread = null;
+
+            private void slideMoveThreadFunc()
+            {
+                while (true)
+                {
+                    slideControlMutex.WaitOne();
+
+                    if (slideMoveRequest.isRequested
+                        && SlideWindow != null)
+                    {
+                        SlideWindow.View.GotoSlide(slideMoveRequest.slideIndex);
+                        slideMoveRequest = (false, -1);
+                    }
+
+                    slideControlMutex.ReleaseMutex();
+                }
+            }
+
+            private void requestMovingSlide(int slideIdx)
+            {
+                if (slideControlThread == null)
+                {
+                    slideControlThread = new System.Threading.Thread(slideMoveThreadFunc) { IsBackground = true };
+                    slideControlThread.Start();
+                }
+
+                slideControlMutex.WaitOne();
+                slideMoveRequest = (true, slideIdx);
                 slideControlMutex.ReleaseMutex();
             }
+
+            // ===========================================================================
 
             public void SlideShowHide()
             {

--- a/BibleProjector-WPF/module/ShowStarter.cs
+++ b/BibleProjector-WPF/module/ShowStarter.cs
@@ -10,6 +10,7 @@ namespace BibleProjector_WPF.module
     public class ShowStarter
     {
         public event Event.ShowStartEventHandler ShowStartEvent;
+        public event EventHandler ShowStartTaskDone;
 
         public void Show(Data.ShowData showData)
         {
@@ -22,7 +23,10 @@ namespace BibleProjector_WPF.module
                 if (showData.canExcuteShow() != Data.ShowExcuteErrorEnum.NoErrors)
                     throw new Exception("슬라이드 쇼를 실행할 수 없는 항목을 표시하려 했습니다. " + showData.canExcuteShow().ToString());
                 else
+                {
                     ShowStartEvent.Invoke(this, new Event.ShowStartEventArgs(showData));
+                    ShowStartTaskDone.Invoke(this, null);
+                }
             }
         }
     }

--- a/BibleProjector-WPF/module/ShowStarter.cs
+++ b/BibleProjector-WPF/module/ShowStarter.cs
@@ -9,6 +9,7 @@ namespace BibleProjector_WPF.module
 {
     public class ShowStarter
     {
+        public event Event.ShowStartEventHandler ShowStartPreparing;
         public event Event.ShowStartEventHandler ShowStartEvent;
         public event EventHandler ShowStartTaskDone;
 
@@ -24,6 +25,7 @@ namespace BibleProjector_WPF.module
                     throw new Exception("슬라이드 쇼를 실행할 수 없는 항목을 표시하려 했습니다. " + showData.canExcuteShow().ToString());
                 else
                 {
+                    ShowStartPreparing.Invoke(this, new Event.ShowStartEventArgs(showData));
                     ShowStartEvent.Invoke(this, new Event.ShowStartEventArgs(showData));
                     ShowStartTaskDone.Invoke(this, null);
                 }

--- a/BibleProjector-WPF/module/StringModifier.cs
+++ b/BibleProjector-WPF/module/StringModifier.cs
@@ -9,10 +9,38 @@ namespace BibleProjector_WPF.module
     class StringModifier
     {
         /// <summary>
-        /// 불필요한 줄바꿈을 지웁니다.
+        /// 불필요한 줄바꿈이 존재하는지를 검사합니다.
         /// <br/><paramref name="input"/>은 윈도우 표준 개행방식으로 처리된 문자열이어야 합니다!
         /// </summary>
         /// <param name="input">입력 문자열</param>
+        /// <returns>출력 문자열</returns>
+        static public bool hasMultiLinefeeds(string input)
+        {
+            int linefeedStack = 0;
+            foreach (char c in input)
+            {
+                if (c == '\n')
+                {
+                    linefeedStack++;
+                    if (linefeedStack == 2)
+                    {
+                        return true;
+                    }
+                }
+
+                if (!char.IsWhiteSpace(c))
+                {
+                    linefeedStack = 0;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// 불필요한 줄바꿈을 지웁니다.
+        /// <br/><paramref name="windowsLineBreakString"/>은 윈도우 표준 개행방식으로 처리된 문자열이어야 합니다!
+        /// </summary>
+        /// <param name="windowsLineBreakString">입력 문자열</param>
         /// <returns>출력 문자열</returns>
         static public string RemoveMultiLinefeeds(string windowsLineBreakString)
         {

--- a/BibleProjector-WPF/module/StringModifier.cs
+++ b/BibleProjector-WPF/module/StringModifier.cs
@@ -9,6 +9,34 @@ namespace BibleProjector_WPF.module
     class StringModifier
     {
         /// <summary>
+        /// 불필요한 줄바꿈을 지웁니다.
+        /// <br/><paramref name="input"/>은 윈도우 표준 개행방식으로 처리된 문자열이어야 합니다!
+        /// </summary>
+        /// <param name="input">입력 문자열</param>
+        /// <returns>출력 문자열</returns>
+        static public string RemoveMultiLinefeeds(string windowsLineBreakString)
+        {
+            StringBuilder output = new StringBuilder("");
+            int startIndex = 0;
+            int count;
+
+            while (true)
+            {
+                while ((startIndex != windowsLineBreakString.Length) && (char.IsWhiteSpace(windowsLineBreakString[startIndex])))
+                    startIndex++;
+                if (startIndex == windowsLineBreakString.Length)
+                    break;
+                count = 1;
+                while ((startIndex + count != windowsLineBreakString.Length) && (windowsLineBreakString[startIndex + count - 1] != '\n'))
+                    count++;
+                output.Append(windowsLineBreakString.Substring(startIndex, count));
+                startIndex += count;
+            }
+
+            return output.ToString();
+        }
+
+        /// <summary>
         /// 잘못된 개행문자를 윈도우 표준에 맞게 바꿔줍니다.
         /// </summary>
         /// <param name="original">


### PR DESCRIPTION
# 추가기능
- 쇼 컨트롤러에서 화살표 키 지속입력시 빠르게 넘기는 기능 추가
  <img src="https://github.com/user-attachments/assets/0f348bd8-802f-4074-9415-ad57e4633879" height="100">
- 곡 추가/수정 화면에서 중복 개행을 제거하는 기능 추가
  <img src="https://github.com/user-attachments/assets/329e8068-cf8a-4637-b721-b84afed9b478" height="500">
- 곡 추가시 수정 탭에 바로 보여지도록 자동으로 화면을 이동하는 기능 추가

# 문제 수정
## 1. UI 스크롤 초기화
- 자료수정/옵션 등으로 화면을 전환 후 다시 컨트롤러로 돌아오면 스크롤 정보 등이 초기화되는 문제 수정
- 성경/찬양을 번갈아 사용하며 조작시 스크롤 정보가 초기화되는 문제 수정
  <img src="https://github.com/user-attachments/assets/3c4455d4-a02a-4aad-ae91-e2f465bce321" height="400">

## 2. 자막 표시 후 컨트롤러 즉시 조작이 불가능
- 자막 표시 후 바로 키보드 조작이 불가능한 문제 수정
- 예약 항목을 더블클릭으로 실행하면 항상 바로 조작이 불가능한 문제 수정
- 성경/찬양 컨트롤러에서 서로 전환되도록 항목을 표시하면 바로 조작이 불가능한 문제 수정
  <img src="https://github.com/user-attachments/assets/922cf458-b87c-4feb-92ae-2f330dc47147" height="400">

## 3. 곡 변경이 적용되지 않음
- 곡 목록 콤보박스를 한번이라도 열면 곡 추가/삭제/이름변경을 해도 반영되지 않는 문제 수정

## 4. 예약 UI의 화면 조작 불가
- 예약리스트 화면(빈 여백/스크롤 바)을 클릭해도 안되어 키보드 입력이 무시되는 문제 수정
- 드래그 후 키보드 조작이 불가능한 문제 수정
  <img src="https://github.com/user-attachments/assets/afa25823-c5cd-4ef0-a2a5-209935a06df8" height="400">

# 기타 변경사항
- 내부 가사 수정 로직 개선
- 외부 PPT의 슬라이드 쇼 이동 로직 개선 (애니메이션이 포함된 PPT 조작시 UI가 멈추는 문제 수정)